### PR TITLE
Refactor exception handling and Client output

### DIFF
--- a/basex/src/main/java/com/formulasearchengine/mathosphere/basex/Benchmark.java
+++ b/basex/src/main/java/com/formulasearchengine/mathosphere/basex/Benchmark.java
@@ -8,6 +8,7 @@ import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xquery.XQException;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -97,10 +98,13 @@ public class Benchmark {
 		} catch ( XPathExpressionException e ) {
 			System.err.println( "XPath Error in query file: " + e.getMessage() );
 			e.printStackTrace();
+		} catch (XQException e ) {
+			System.err.println( "Error in connection to the server: " + e.getMessage() );
+			e.printStackTrace();
 		}
 	}
 
-	private void run() throws IOException, ParserConfigurationException, SAXException, XPathExpressionException {
+	private void run() throws IOException, ParserConfigurationException, SAXException, XPathExpressionException, XQException {
 		File f = new File( line.getOptionValue( "datasource" ) );
 		Server srv = Server.getInstance();
 		srv.startup(f);

--- a/basex/src/main/java/com/formulasearchengine/mathosphere/basex/types/Result.java
+++ b/basex/src/main/java/com/formulasearchengine/mathosphere/basex/types/Result.java
@@ -3,6 +3,7 @@ package com.formulasearchengine.mathosphere.basex.types;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +26,9 @@ public class Result {
 	@XStreamImplicit
 	private List<Hit> hits;
 
+	@XStreamOmitField
+	private boolean showTime = true;
+
 	public Result( String queryIDNum, Long ms ) {
 		this.ms = ms == null ? "" : String.valueOf( ms );
 		this.queryID = queryIDNum;
@@ -34,6 +38,15 @@ public class Result {
 	public Result( String queryIDNum ) {
 		this.queryID = queryIDNum;
 		this.hits = new ArrayList<>();
+		this.ms = "";
+	}
+
+	public void setShowTime( boolean showTime ) {
+		this.showTime = showTime;
+	}
+
+	public boolean getShowTime() {
+		return showTime;
 	}
 
 	public Long getTime() {

--- a/basex/src/main/java/com/formulasearchengine/mathosphere/basex/types/Results.java
+++ b/basex/src/main/java/com/formulasearchengine/mathosphere/basex/types/Results.java
@@ -3,6 +3,7 @@ package com.formulasearchengine.mathosphere.basex.types;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +23,9 @@ public class Results {
 	@XStreamAsAttribute
 	private String xmlns="http://ntcir-math.nii.ac.jp/";
 
+	@XStreamOmitField
+	private boolean showTime = true;
+
 	public Results() {
 		this.runs = new ArrayList<>();
 		//hack b/c xstream does not support default values
@@ -33,12 +37,29 @@ public class Results {
 		this.xmlns = xmlns;
 	}
 
+	public void setShowTime( boolean showTime ) {
+		this.showTime = showTime;
+		if ( runs != null ) {
+			for ( final Run run : runs ) {
+				run.setShowTime( showTime );
+			}
+		}
+	}
+
+	public boolean getShowTime() {
+		return this.showTime;
+	}
+
 	public void addRun( Run run ) {
+		run.setShowTime( showTime );
 		this.runs.add( run );
 	}
 
 	public void setRuns( List<Run> runs ) {
 		this.runs = new ArrayList<>( runs );
+		for ( final Run run : runs ) {
+			run.setShowTime( showTime );
+		}
 	}
 
 	public List<Run> getRuns() {

--- a/basex/src/main/java/com/formulasearchengine/mathosphere/basex/types/Run.java
+++ b/basex/src/main/java/com/formulasearchengine/mathosphere/basex/types/Run.java
@@ -3,6 +3,7 @@ package com.formulasearchengine.mathosphere.basex.types;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +30,9 @@ public class Run {
 	@XStreamImplicit
 	private List<Result> results;
 
+	@XStreamOmitField
+	private boolean showTime = true;
+
 	public Run( String runtag, Long ms, String type ) {
 		this.runtag = runtag;
 		this.ms = ms == null ? "" : String.valueOf( ms );
@@ -40,6 +44,21 @@ public class Run {
 		this.runtag = runtag;
 		this.type = type;
 		this.results = new ArrayList<>();
+		this.ms = "";
+	}
+
+	public void setShowTime( boolean showTime ) {
+		this.showTime = showTime;
+
+		if ( results != null ) {
+			for ( final Result result : results ) {
+				result.setShowTime( showTime );
+			}
+		}
+	}
+
+	public boolean getShowTime() {
+		return this.showTime;
 	}
 
 	public void setTime( Long ms ) {
@@ -47,6 +66,7 @@ public class Run {
 	}
 
 	public void addResult( Result result ) {
+		result.setShowTime( showTime );
 		results.add( result );
 	}
 
@@ -56,6 +76,10 @@ public class Run {
 
 	public void setResults( List<Result> results ) {
 		this.results = new ArrayList<>( results );
+
+		for ( final Result result : results ) {
+			result.setShowTime( showTime );
+		}
 	}
 
 	public int getNumResults() {

--- a/basex/src/test/java/com/formulasearchengine/mathosphere/basex/XStreamTest.java
+++ b/basex/src/test/java/com/formulasearchengine/mathosphere/basex/XStreamTest.java
@@ -26,10 +26,12 @@ public class XStreamTest {
 		result.addHit( hit );
 		result.addHit( hit2 );
 
+		result.setShowTime( true );
+
 		XMLUnit.setIgnoreWhitespace( true );
 		XMLUnit.setIgnoreAttributeOrder( true );
 		XMLAssert.assertXMLEqual( TestUtils.getFileContents( TestUtils.BASEX_RESOURCE_DIR + "testResultToXML.xml" ),
-				Client.resultToXML( result, true ) );
+				Client.resultToXML( result ) );
 
 	}
 
@@ -51,10 +53,12 @@ public class XStreamTest {
 		results.addRun( run );
 		results.addRun( run2 );
 
+		results.setShowTime( true );
+
 		XMLUnit.setIgnoreWhitespace( true );
 		XMLUnit.setIgnoreAttributeOrder( true );
 		XMLAssert.assertXMLEqual( TestUtils.getFileContents( TestUtils.BASEX_RESOURCE_DIR + "testResultsToXML.xml" ),
-				Client.resultsToXML( results, true ) );
+				Client.resultsToXML( results ) );
 	}
 
 	@Test
@@ -62,9 +66,13 @@ public class XStreamTest {
 		final String file = TestUtils.getFileContents( TestUtils.BASEX_RESOURCE_DIR + "testResultToXML.xml" );
 		final Result result = (Result) Client.xmlToClass( file, Result.class );
 
+		result.setShowTime( true );
+
+		System.out.println( "RES:\n" + Client.resultToXML( result ) );
+
 		XMLUnit.setIgnoreWhitespace( true );
 		XMLUnit.setIgnoreAttributeOrder( true );
-		XMLAssert.assertXMLEqual( file, Client.resultToXML( result, true ) );
+		XMLAssert.assertXMLEqual( file, Client.resultToXML( result ) );
 	}
 
 	@Test
@@ -72,9 +80,11 @@ public class XStreamTest {
 		final String file = TestUtils.getFileContents( TestUtils.BASEX_RESOURCE_DIR + "testResultsToXML.xml" );
 		final Results results = (Results) Client.xmlToClass( file, Results.class );
 
+		results.setShowTime( true );
+
 		XMLUnit.setIgnoreWhitespace( true );
 		XMLUnit.setIgnoreAttributeOrder( true );
-		XMLAssert.assertXMLEqual( file, Client.resultsToXML( results, true ) );
+		XMLAssert.assertXMLEqual( file, Client.resultsToXML( results ) );
 	}
 
 	@Test
@@ -95,9 +105,11 @@ public class XStreamTest {
 		results.addRun( run );
 		results.addRun( run2 );
 
+		results.setShowTime( false );
+
 		final String file = TestUtils.getFileContents( TestUtils.BASEX_RESOURCE_DIR + "testResultsShowTime.xml" );
 		XMLUnit.setIgnoreWhitespace( true );
 		XMLUnit.setIgnoreAttributeOrder( true );
-		XMLAssert.assertXMLEqual( file, Client.resultsToXML( results, false ) );
+		XMLAssert.assertXMLEqual( file, Client.resultsToXML( results ) );
 	}
 }


### PR DESCRIPTION
* Make TexQueryGenerator and Client throw exceptions to indicate errors
  rather than returning a string with the error message. This makes it
	much easier to tell when something went wrong.
* Make Client functions return Results and Result objects rather than
  an XML string. This makes it much easier to manipulate the objects for
	later functionality (such as pagination)
* As above, make MathRequest store Results objects.

Resolves #68