### PR TITLE
Remove sdk oracle java 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
 - openjdk7
-- oraclejdk7
 before_install:
   - mvn clean
 after_success:


### PR DESCRIPTION
For some reason the open jdk test was successful, but oracle jdk fails.
cf https://travis-ci.org/TU-Berlin/mathosphere/builds/82331416